### PR TITLE
Add TiDB MCP server as a new partner

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Finding the right MCP server can be challenging. This repository aims to:
 | [Apache Doris & VeloDB](./docs/doris.md) | High-performance analytical database | [GitHub](https://github.com/morningman/mcp-doris) | - |
 | [Confluent](./docs/confluent.md) | Data streaming platform based on Apache Kafka | [GitHub](https://github.com/confluentinc/mcp-confluent) | - |
 | [PagerDuty](./docs/pagerduty.md) | Incident management platform | [GitHub](https://github.com/wpfleger96/pagerduty-mcp-server) | - |
+| [TiDB](./docs/tidb.md) | Distributed SQL database | [GitHub](https://github.com/c4pt0r/mcp-server-tidb) | - |
 
 ## Contributing
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -17,22 +17,23 @@ This document provides a comparison of the various ISV partner MCP servers to he
 | [Apache Doris & VeloDB](./doris.md) | MPP Analytical Database | High-performance, real-time analytics | OLAP workloads, business intelligence, dashboards |
 | [Confluent](./confluent.md) | Data Streaming Platform | Event streaming, topic management | Real-time data pipelines, event-driven architectures |
 | [PagerDuty](./pagerduty.md) | Incident Management Platform | On-call scheduling, incident tracking | DevOps, SRE, IT operations |
+| [TiDB](./tidb.md) | Distributed SQL Database | Horizontal scalability, HTAP capabilities | Cloud-native applications, hybrid workloads |
 
 ## Feature Comparison
 
-| Feature | Zilliz | OceanBase | StarRocks | Snowflake | Databricks | SeaTunnel | Dify | MongoDB | Doris/VeloDB | Confluent | PagerDuty |
-|---------|--------|-----------|-----------|-----------|------------|-----------|------|---------|-------------|-----------|----------|
-| SQL Support | Limited | Full | Full | Full | Full | Limited | No | Limited | Full | Limited | No |
-| Vector Search | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Real-time Analytics | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ |
-| Data Integration | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ |
-| Machine Learning | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
-| Data Sharing | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ |
-| LLM Integration | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
-| Cloud Native | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Event Streaming | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ |
-| Incident Management | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
-| Document Storage | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ |
+| Feature | Zilliz | OceanBase | StarRocks | Snowflake | Databricks | SeaTunnel | Dify | MongoDB | Doris/VeloDB | Confluent | PagerDuty | TiDB |
+|---------|--------|-----------|-----------|-----------|------------|-----------|------|---------|-------------|-----------|----------|------|
+| SQL Support | Limited | Full | Full | Full | Full | Limited | No | Limited | Full | Limited | No | Full |
+| Vector Search | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Real-time Analytics | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ | ✅ |
+| Data Integration | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ |
+| Machine Learning | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Data Sharing | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ |
+| LLM Integration | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Cloud Native | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Event Streaming | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ |
+| Incident Management | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ |
+| Document Storage | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
 
 ## Implementation Complexity
 
@@ -49,6 +50,7 @@ This document provides a comparison of the various ISV partner MCP servers to he
 | Apache Doris & VeloDB | Medium | Medium | Medium |
 | Confluent | Medium | High | Medium |
 | PagerDuty | Low | Low | Low |
+| TiDB | Medium | Medium | Medium |
 
 ## Use Case Scenarios
 
@@ -120,3 +122,10 @@ This document provides a comparison of the various ISV partner MCP servers to he
 - Teams needing automated escalation policies
 - Organizations requiring incident tracking and analytics
 - Services requiring reliable alerting and notification systems
+
+### When to use TiDB
+- Applications requiring horizontal scalability
+- Cloud-native applications with high availability needs
+- Hybrid transactional and analytical processing (HTAP) workloads
+- Systems that need MySQL compatibility with distributed capabilities
+- Applications that need to scale out without complex sharding

--- a/docs/tidb.md
+++ b/docs/tidb.md
@@ -1,0 +1,105 @@
+# TiDB MCP Server
+
+## Overview
+
+TiDB is a distributed SQL database designed for high performance and horizontal scalability. The TiDB MCP server enables AI models to interact with TiDB databases, allowing for SQL queries, data manipulation, and database management operations.
+
+## Features
+
+- SQL query execution and data retrieval
+- Database and table management
+- Transaction support
+- User management
+- Support for TiDB Cloud serverless databases
+
+## Installation
+
+```bash
+# Clone the repository
+git clone https://github.com/c4pt0r/mcp-server-tidb
+cd mcp-server-tidb
+
+# Install dependencies using uv
+uv venv
+uv pip install -e .
+```
+
+## Configuration
+
+```json
+{
+  "mcpServers": {
+    "tidb": {
+      "command": "bash",
+      "args": [
+        "-c",
+        "cd /path/to/mcp-server-tidb && source .venv/bin/activate && python src/main.py"
+      ],
+      "env": {
+        "TIDB_HOST": "gateway01.us-east-1.prod.aws.tidbcloud.com",
+        "TIDB_PORT": "4000",
+        "TIDB_USERNAME": "username",
+        "TIDB_PASSWORD": "password",
+        "TIDB_DATABASE": "test"
+      }
+    }
+  }
+}
+```
+
+For TiDB Cloud, you can create a free database cluster at [tidbcloud.com](https://tidbcloud.com).
+
+## Available Tools
+
+| Tool Name | Description | Input Schema |
+|-----------|-------------|------------|
+| `show_tables` | Show all tables in the database | Database name |
+| `db_query` | Execute SQL query and return results | Database name, SQL query string |
+| `show_create_table` | Get the CREATE TABLE statement for a table | Database name, table name |
+| `db_execute` | Execute SQL statements on a database | Database name, SQL statements (string or list of strings) |
+| `create_db_user` | Create a new database user | Username, password |
+| `remove_db_user` | Remove a database user | Username |
+| `get_tidb_serverless_address` | Get connection host and port | None |
+
+## Usage Examples
+
+```python
+# Example: Querying data from a table
+response = await claude.use_mcp_tool(
+    server_name="tidb",
+    tool_name="db_query",
+    arguments={
+        "db_name": "sales",
+        "sql": "SELECT customer_id, SUM(amount) FROM orders GROUP BY customer_id ORDER BY SUM(amount) DESC LIMIT 5"
+    }
+)
+
+# Example: Creating a new table
+response = await claude.use_mcp_tool(
+    server_name="tidb",
+    tool_name="db_execute",
+    arguments={
+        "db_name": "sales",
+        "sql_stmts": "CREATE TABLE customers (id INT PRIMARY KEY, name VARCHAR(100), email VARCHAR(100))"
+    }
+)
+
+# Example: Inserting data
+response = await claude.use_mcp_tool(
+    server_name="tidb",
+    tool_name="db_execute",
+    arguments={
+        "db_name": "sales",
+        "sql_stmts": [
+            "INSERT INTO customers VALUES (1, 'John Doe', 'john@example.com')",
+            "INSERT INTO customers VALUES (2, 'Jane Smith', 'jane@example.com')"
+        ]
+    }
+)
+```
+
+## References
+
+- [Official TiDB Documentation](https://docs.pingcap.com/tidb/stable)
+- [TiDB Cloud](https://tidbcloud.com)
+- [GitHub Repository](https://github.com/c4pt0r/mcp-server-tidb)


### PR DESCRIPTION
This PR adds TiDB MCP server as a new partner to the MCP Partner Hub.

Changes:
- Added TiDB documentation in docs/tidb.md
- Updated README.md to include TiDB in the list of available MCP servers
- Updated comparison.md to include TiDB in all comparison tables and added a "When to use TiDB" section

TiDB MCP server repository: https://github.com/c4pt0r/mcp-server-tidb